### PR TITLE
Use freedesktop specification for config location

### DIFF
--- a/photini/configstore.py
+++ b/photini/configstore.py
@@ -24,7 +24,7 @@ from PyQt4 import QtCore
 class ConfigStore(object):
     def __init__(self):
         self.config = SafeConfigParser()
-        self.file_name = os.path.expanduser('~/photini.ini')
+        self.file_name = os.path.expanduser('~/.config/photini/photini.ini')
         self.config.read(self.file_name)
         self.timer = QtCore.QTimer()
         self.timer.setSingleShot(True)


### PR DESCRIPTION
According to freedesktop specs [1] location of configuration files should be
under ~/.config by default. This way the ~/ directory is not filled with
configuration files of different software.

This commit sets the default config  at
~/.config/photini/photini.ini

[1] http://www.freedesktop.org/wiki/Specifications/config-spec/
