### PR TITLE
Proxy error

### DIFF
--- a/src/photini/editor.py
+++ b/src/photini/editor.py
@@ -34,9 +34,10 @@ import os
 import sys
 if sys.version_info[0] >= 3:
     from urllib.request import getproxies
+    from urllib.parse import urlparse
 else:
     from urllib import getproxies
-from urlparse import urlparse 
+    from urlparse import urlparse 
 import webbrowser
 
 from PyQt4 import QtGui, QtCore


### PR DESCRIPTION
I was getting an error when Photini tried to set my network proxy. 
`ValueError: invalid literal for int() with base 10: '3128/'`
It was picking up the trailing slash at the end. I did some research and found [urlparse](https://docs.python.org/2/library/urlparse.html). It seems to be just what's needed here. 

This is my first pull request, so be gentle if there are any problems. 
