### PR TITLE
added PHOTINI_CONFIG environt variable

### DIFF
--- a/src/photini/configstore.py
+++ b/src/photini/configstore.py
@@ -35,10 +35,15 @@ class BaseConfigStore(object):
         super(BaseConfigStore, self).__init__(*arg, **kw)
         self.dirty = False
         self.config = RawConfigParser()
-        if hasattr(appdirs, 'user_config_dir'):
-            config_dir = appdirs.user_config_dir('photini')
-        else:
-            config_dir = appdirs.user_data_dir('photini')
+        # determine configuration file location
+        config_dir = os.environ.get('PHOTINI_CONFIG')
+        if config_dir:
+            config_dir = os.path.expanduser(config_dir)
+        if not config_dir:
+            if hasattr(appdirs, 'user_config_dir'):
+                config_dir = appdirs.user_config_dir('photini')
+            else:
+                config_dir = appdirs.user_data_dir('photini')
         if not os.path.isdir(config_dir):
             os.makedirs(config_dir, mode=stat.S_IRWXU)
         self.file_name = os.path.join(config_dir, name + '.ini')


### PR DESCRIPTION
Adds a configuration variable (PHOTINI_CONFIG) as an alternative to determine the location of the configuration. If the configuration variable is not set (in the os), the behavior does not change from present.

Motivation: I locate the configuration in an area that is backed up to a cloud service (Dropbox) and also shared between several computers I use Photini with.