### PR TITLE
Fix spelling fallback for unsupported UI locale

### DIFF
--- a/src/photini/spelling.py
+++ b/src/photini/spelling.py
@@ -38,6 +38,19 @@ else:
     spelling_version = None
 
 
+class NullDictionary(object):
+    tag = ''
+
+    def check(self, word):
+        return True
+
+    def suggest(self, word):
+        return []
+
+    def __bool__(self):
+        return False
+
+
 class SpellCheck(QtCore.QObject):
     new_dict = QtSignal()
 
@@ -96,8 +109,16 @@ class SpellCheck(QtCore.QObject):
                 if code.startswith(test):
                     self.dictionaries[lang] = enchant.request_dict(code)
                     return
-        self.dictionaries[lang] = self.dictionaries[self.default_lang]
-        return
+        if lang != self.default_lang:
+            self.load_dict(self.default_lang)
+            if self.default_lang in self.dictionaries:
+                self.dictionaries[lang] = self.dictionaries[self.default_lang]
+                return
+        for code in enchant.list_languages():
+            self.dictionaries[lang] = enchant.request_dict(code)
+            return
+        logger.warning('No dictionary available for %s', lang)
+        self.dictionaries[lang] = NullDictionary()
 
     def set_language(self, code):
         if code:


### PR DESCRIPTION
I have locale:
> locale
LANG=cs_CZ.UTF-8
LANGUAGE=
LC_CTYPE="cs_CZ.UTF-8"
LC_NUMERIC="cs_CZ.UTF-8"
LC_TIME="cs_CZ.UTF-8"
LC_COLLATE="cs_CZ.UTF-8"
LC_MONETARY="cs_CZ.UTF-8"
LC_MESSAGES="cs_CZ.UTF-8"
LC_PAPER="cs_CZ.UTF-8"
LC_NAME="cs_CZ.UTF-8"
LC_ADDRESS="cs_CZ.UTF-8"
LC_TELEPHONE="cs_CZ.UTF-8"
LC_MEASUREMENT=cs_CZ.UTF8
LC_IDENTIFICATION="cs_CZ.UTF-8"
LC_ALL=

Photini reports error:
20:25:26: ERROR: photini.pyqt: 'cs-CZ'
  Traceback (most recent call last):
File "/home/skim/44_git/Photini/src/photini/pyqt.py", line 175, in wrapper
      return func(*args, **kwds)
             ^^^^^^^^^^^^^^^^^^^
File "/home/skim/44_git/Photini/src/photini/editor.py", line 568, in new_tab
      current.refresh()
File "/home/skim/44_git/Photini/src/photini/descriptive.py", line 194, in refresh
      self.new_selection(self.app.image_list.get_selected_images())
File "/home/skim/44_git/Photini/src/photini/descriptive.py", line 200, in new_selection
      self.widget().load_data(selection)
File "/home/skim/44_git/Photini/src/photini/widgets/__init__.py", line 220, in load_data
      widget.set_value(None)
File "/home/skim/44_git/Photini/src/photini/widgets/__init__.py", line 118, in set_value
      self.set_subwidgets(value)
File "/home/skim/44_git/Photini/src/photini/widgets/text.py", line 787, in set_subwidgets
      self.edit_stack.set_langs(keys)
File "/home/skim/44_git/Photini/src/photini/widgets/text.py", line 481, in set_langs
      self.add_lang(lang)
File "/home/skim/44_git/Photini/src/photini/widgets/text.py", line 444, in add_lang
      widget.set_lang(lang)
File "/home/skim/44_git/Photini/src/photini/widgets/text.py", line 410, in set_lang
      self._spell_check.set_lang(lang)
File "/home/skim/44_git/Photini/src/photini/widgets/text.py", line 102, in set_lang
      self.spell_check.load_dict(lang)
File "/home/skim/44_git/Photini/src/photini/spelling.py", line 99, in load_dict
      self.dictionaries[lang] = self.dictionaries[self.default_lang]
                                ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  KeyError: 'cs-CZ'